### PR TITLE
upgrade to nalgebra 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ exclude = ["/target"]
 include = ["*.gml", "*.rs", "*.toml", "*.md", "LICENSE"]
 
 [dependencies]
-nalgebra = "0.13"
+nalgebra = "0.15.3"
 munkres = "0.4"
 closed01 = "0.4"
 petgraph = "0.4"
-approx = "0.1"
+approx = "0.3.0"
 
 [dev-dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 ///
 /// TODO: Introduce EdgeWeight trait to abstract edge weight similarity.
 
-#[macro_use]
 extern crate approx;
 extern crate closed01;
 extern crate munkres;
@@ -23,6 +22,7 @@ extern crate graph_io_gml;
 #[cfg(test)]
 extern crate test;
 
+use approx::RelativeEq;
 use nalgebra::DMatrix;
 use munkres::{solve_assignment, WeightMatrix};
 use std::cmp;
@@ -193,7 +193,7 @@ where
     }
 
     fn in_eps(&self, eps: f32) -> bool {
-        relative_eq!(self.previous, self.current, epsilon = eps)
+        self.previous.relative_eq(&self.current, eps, f32::default_max_relative())
     }
 
     /// Calculates the next iteration of the similarity matrix (x[k+1]).


### PR DESCRIPTION
...to avoid an incoherence issue in the future when rust-lang/rust#49799 lands

Weirdly, I had to manually expand this macro:
```rust
196 |         relative_eq!(self.previous, self.current, epsilon = eps)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `approx::RelativeEq` is not implemented for `nalgebra::Matrix<f32, nalgebra::Dynamic, nalgebra::Dynamic, nalgebra::MatrixVec<f32, n
algebra::Dynamic, nalgebra::Dynamic>>`
    |
    = note: required by `approx::Relative`
```

My guess is somehow `impl<N: Scalar, R: DimName> Storage<N, R, Dynamic> for MatrixVec<N, R, Dynamic> ` doesn't cover `MatrixVec<f32, Dynamic, Dynamic>`.